### PR TITLE
Anpassung der Ausrichtung von Icon und Text in Kalendereinträgen

### DIFF
--- a/lib/css/style.css
+++ b/lib/css/style.css
@@ -505,7 +505,7 @@ h6 {font-size:1em;}
 						.single article.termine {background: #fff; margin: 1em;padding: 1em;}
 							.single article.termine .termin_meta {margin: 1em 0 1em 0;color: #0a321e;font-family: 'Arvo Regular', 'Arvo Gruen', Trebuchet, Helvetica Neue, Helvetica, Arial, Verdana, sans-serif;font-size: 0.9em;							}
 								.single article.termine .termin_meta span {display: block;margin-bottom: 0.5em;}
-								.single article.termine .termin_meta span:before {padding-right: 0.5em;font-family: "FontAwesome";color: #46962b;font-size: 1.3em;	}
+								.single article.termine .termin_meta span:before {padding-right: 0.5em;font-family: "FontAwesome";color: #46962b;font-size: 1.3em;display: inline-block;width: 1em;text-align: center;}
 								.single article.termine .termin_meta .termin_tag:before {content: "\f073";}
 								.single article.termine .termin_meta .termin_zeit:before {content: "\f017";}
 								.single article.termine .termin_meta .termin_ort:before  {content: "\f041";}


### PR DESCRIPTION
Da in FontAwesome jedes Zeichen seine individuelle Breite hat, ist bei mehreren Kombinationen von Icon und Text untereinander die Schrift-Ausrichtung immer eine andere. Dieser PR gibt jedem Icon eine "bounding box" von 1 em und richtet das Icon darin mittig aus.

Vorher:

![vorher](https://user-images.githubusercontent.com/273727/37986649-51fef04c-31fc-11e8-8b0c-ef345a1e78da.png)

Nachher:

![nachher](https://user-images.githubusercontent.com/273727/37986656-567df262-31fc-11e8-9d36-6650d9b8c04b.png)
