### PR TITLE
Aktualisierung der Links im "portalmenu"

### DIFF
--- a/functions/theme-functions.php
+++ b/functions/theme-functions.php
@@ -263,10 +263,10 @@ function kr8_nav_footer_fallback() {
 // this is the fallback for portal menu
 function kr8_nav_portal_fallback() { ?>
 	<ul id="menu-portalmenu" class="navigation">
-		<li><a href="http://gruene.de">Bundesverband</a></li>
-		<li><a href="http://gruene-fraktion.de">Bundestagsfraktion</a></li>
-		<li><a href="http://gruene-jugend.de">Grüne Jugend</a></li>
-		<li><a href="http://boell.de">Böll Stiftung</a></li>
+		<li><a href="https://gruene.de/">Bundesverband</a></li>
+		<li><a href="https://www.gruene-bundestag.de/">Bundestagsfraktion</a></li>
+		<li><a href="https://gruene-jugend.de/">Grüne Jugend</a></li>
+		<li><a href="https://www.boell.de/">Böll Stiftung</a></li>
 	</ul>
 <?php }
 


### PR DESCRIPTION
Alle vier verlinkten Sites nutzen inzwischen HTTPS. Es gibt noch weitere URL-Änderungen.

Zwar führen die bestehenden URLs auch ans Ziel, aber je weniger Redirects dafür benötigt werden, desto besser für die Nutzer*innen. Könnte evtl. auch aus SEO-Sicht relevant sein.

- `http://gruene.de` -> `https://gruene.de/`
- `http://gruene-fraktion.de` -> `https://www.gruene-bundestag.de/`
- `http://gruene-jugend.de` -> `https://gruene-jugend.de/`
- `http://boell.de` -> `https://www.boell.de/`
