### PR TITLE
CSS-Anpassung am Suchfeld

### DIFF
--- a/lib/css/style.css
+++ b/lib/css/style.css
@@ -831,7 +831,7 @@ h6 {font-size:1em;}
 				#header.widthimg #logo{position: absolute;left: 1em;top: 30%;  }	  	
 	  	
 	  	
-	  	#portal .searchform {background: #fff; border: 0;padding: 0.2em;border-radius: 1em;font-size: 0.9em; }
+	  	#portal .searchform {background: #fff; border: 0;padding: 0 0.3em;border-radius: 1em;font-size: 0.9em; }
 	  				#portal .suche {display: inline-block;}
 	  				#portal .searchform label {	position: absolute;top: -9999999px;   				}
 	  				#portal .searchform:hover {box-shadow:0 0 6px #1e5b13,0 0 10px #aaa inset;color: #555;}


### PR DESCRIPTION
Das Such-Eingabefeld ist ein bisschen höher als notig. Dadurch hat es nicht ganz die typische "Pillenform", bei der links und rechts jeweils ein Halbkreis entsteht.

Vorher:

![image](https://user-images.githubusercontent.com/273727/37990094-96fa8ffe-3205-11e8-9e1d-5f4f3d691b34.png)

Nachher:

![image](https://user-images.githubusercontent.com/273727/37990101-9aefe5b4-3205-11e8-8f81-223c95c85df8.png)

