### PR TITLE
Kompaktere Typo im Sidebar

### DIFF
--- a/lib/css/style.css
+++ b/lib/css/style.css
@@ -1075,7 +1075,7 @@ h6 {font-size:1em;}
   .sidebar {margin-top: 0;padding: 0;	background: transparent;color: #333;}
 	.sidebar.threecol  a:hover {color: #0a321e; }
 	.sidebar.threecol a {color: #46962b;}
-  .widget {margin: 0 0 2em 0;padding: 1.5em;border: 0;background: #e6e6e6;box-shadow: 5px 5px 10px rgba(0,0,0,0.2);}
+  .widget {margin: 0 0 2em 0;padding: 1.1em;border: 0;background: #e6e6e6;box-shadow: 5px 5px 10px rgba(0,0,0,0.2);}
   	.sidebar .widget:last-of-type {margin-bottom: 2em;}
   	.widget ul li {margin-bottom: 0.5em;/* deep nesting */}
   	.widget ul li ul {margin-top: 0.75em;padding-left: 1em;}

--- a/lib/css/style.css
+++ b/lib/css/style.css
@@ -1076,6 +1076,7 @@ h6 {font-size:1em;}
 	.sidebar.threecol  a:hover {color: #0a321e; }
 	.sidebar.threecol a {color: #46962b;}
   .widget {margin: 0 0 2em 0;padding: 1.1em;border: 0;background: #e6e6e6;box-shadow: 5px 5px 10px rgba(0,0,0,0.2);}
+    .widget p {line-height: 1.35em;}
   	.sidebar .widget:last-of-type {margin-bottom: 2em;}
   	.widget ul li {margin-bottom: 0.5em;/* deep nesting */}
   	.widget ul li ul {margin-top: 0.75em;padding-left: 1em;}

--- a/lib/css/style.css
+++ b/lib/css/style.css
@@ -630,7 +630,7 @@ h6 {font-size:1em;}
 *********************/
 .sidebar li {list-style-type: none;}
 .sidebar {background:#0a321e;padding: 2em;color: #8d9e96;}
-  h3.widgettitle {margin-bottom: 0.5em;color: #fff;}
+  h3.widgettitle {margin-bottom: 0.5em;color: #fff;line-height: 1.25em;font-size: 1.3em;}
   .sidebar a, .sidebar a:visited {color: #afdca7; }
   .sidebar a:hover {color: #ffe000; }
 .widget {margin-bottom: 2em;border-bottom: 2px solid #17452e; padding-bottom: 2em;}


### PR DESCRIPTION
Hier ein Vorschlag, die Inhalte in den Sidebar-Widgets kompakter zu machen. Dieser PR ändert mehrere Details:

- Weniger padding für die Widgets
- Kleinere Widget-Überschriften, geringerer Zeilenabstand
- Geringerer Zeilenabstand in `<p></p>` Text.

Vorher:

![image](https://user-images.githubusercontent.com/273727/37990839-b022e8e4-3207-11e8-9bc8-daa776c5b3d6.png)

Nachher:

![image](https://user-images.githubusercontent.com/273727/37990868-cb2c9f2c-3207-11e8-999c-085856d8b876.png)
