### PR TITLE
Horizontaler Abstand im Breadcrumb

### DIFF
--- a/functions/theme-functions.php
+++ b/functions/theme-functions.php
@@ -617,11 +617,11 @@ Breadcrumb
 if ( ! function_exists ( 'nav_breadcrumb' ) ) {
 function nav_breadcrumb() {
  
-  $delimiter = '&rang;';
   $home = 'Startseite'; 
   $before = '<span class="current">'; 
   $after = '</span>'; 
  
+  $delimiter = '<span class="delimiter">&rang;</span>';
   if ( !is_front_page() || is_paged() ) {
  
     echo '<div id="breadcrumb">';

--- a/lib/css/style.css
+++ b/lib/css/style.css
@@ -899,7 +899,8 @@ h6 {font-size:1em;}
   
   	#breadcrumb {display: block; z-index: 2;position: relative; background: #ffee00;color:#0a321e;padding: 0.3em 1em;font-size: 0.9em;font-family: 'PT Sans Bold', Trebuchet, Helvetica Neue, Helvetica, Arial, Verdana, sans-serif; }
   		#breadcrumb a {color:#0a321e;}
-  	
+      #breadcrumb .delimiter {display: inline-block; padding: 0 0.4em;}
+
   	.navwrap {margin-bottom: 2em; }
 
 	.nav-footer {font-size: 0.8em;margin: 2em 0 3em 0;}


### PR DESCRIPTION
Dieser PR ermöglicht, den Trenner im Breadcrumb per CSS anzupassen und fügt einen horizontalen Abstand ein, um die Lesbarkeit und Optik zu verbessern.

Vorher:

![image](https://user-images.githubusercontent.com/273727/37992015-ec9fd1f8-320a-11e8-9290-f64e589e6e36.png)

Nachher:

![image](https://user-images.githubusercontent.com/273727/37992029-f66a981c-320a-11e8-88e1-f40959e77c95.png)
