### PR TITLE
Horizontaler Abstand zwischen Widgets im Footer

### DIFF
--- a/header.php
+++ b/header.php
@@ -102,7 +102,9 @@
 					
 					<div class="hgroup">
 						<h1 id="site-title"><span><a href="<?php echo esc_url( home_url( '/' ) ); ?>" title="<?php echo esc_attr( get_bloginfo( 'name', 'display' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></span></h1>
+						<?php if (get_bloginfo('description') !== '') : ?>
 						<h2 id="site-description"><?php bloginfo( 'description' ); ?></h2>
+						<?php endif; ?>
 					</div>
 				<?php endif; ?>
 												

--- a/lib/css/style.css
+++ b/lib/css/style.css
@@ -688,7 +688,10 @@ h6 {font-size:1em;}
 	.widget_rss h3 img {display: none;}
 		#footer .widget_rss h3 a {color: #fff;}
 
-	
+  #footer .widget {margin-left: 1em;margin-right: 1em;}
+  #footer .widget:first-of-type {margin-left: 0em;}
+  #footer .widget:last-of-type {margin-right: 0em;}
+
 	/*Termine: Liste */
 	.widget_termine_liste_widget {}
 		.widget_termine_liste_widget li li {}


### PR DESCRIPTION
Platziert man im Footer zwei RSS-Widgets nebeneinander, fällt auf, dass die Widgets keinen Abstand zueinander haben. Dieser PR fügt 1em dazwischen ein.

Vorher:

![vorher](https://user-images.githubusercontent.com/273727/38098817-422c03e8-3379-11e8-8eca-75f7305649ad.png)

Nachher:

![nachher](https://user-images.githubusercontent.com/273727/38098819-44249124-3379-11e8-846b-2a69bedf9194.png)