### PR TITLE
Vertikalen Abstand im Header-Logo entfernen

### DIFF
--- a/header.php
+++ b/header.php
@@ -102,7 +102,9 @@
 					
 					<div class="hgroup">
 						<h1 id="site-title"><span><a href="<?php echo esc_url( home_url( '/' ) ); ?>" title="<?php echo esc_attr( get_bloginfo( 'name', 'display' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></span></h1>
+						<?php if (get_bloginfo('description') !== '') : ?>
 						<h2 id="site-description"><?php bloginfo( 'description' ); ?></h2>
+						<?php endif; ?>
 					</div>
 				<?php endif; ?>
 												


### PR DESCRIPTION
Wenn das Blog keine Beschreibung hat, entsteht im Logo ein ungewünschter Abstand. Dieser PR behebt das.

Vorher:

![image](https://user-images.githubusercontent.com/273727/38172359-47618f34-35ab-11e8-8988-3788eea17eab.png)


Nachher:

![image](https://user-images.githubusercontent.com/273727/38172362-4b991676-35ab-11e8-9086-ab4dd72b7408.png)
