### PR TITLE
Alternatives Logo durch Childtheme

### DIFF
--- a/header.php
+++ b/header.php
@@ -98,7 +98,12 @@
 			<?php } ?>
 
 				<?php if ( display_header_text() ) : ?>
-					<p id="logo"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" title="Zur Startseite"><img src="<?php echo get_stylesheet_directory_uri(); ?>/lib/images/logo.png" width="185" height="100" alt="<?php bloginfo('name'); ?>"></a></p>
+					<p id="logo"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" title="Zur Startseite"><img src="
+					<?php 
+						$logopath = "lib/images/logo.png";
+						$abslogopath = locate_template($logopath);
+						echo get_site_url() . substr($abslogopath, strlen(get_home_path())-1);
+					?>" width="185" height="100" alt="<?php bloginfo('name'); ?>"></a></p>
 					
 					<div class="hgroup">
 						<h1 id="site-title"><span><a href="<?php echo esc_url( home_url( '/' ) ); ?>" title="<?php echo esc_attr( get_bloginfo( 'name', 'display' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></span></h1>

--- a/header.php
+++ b/header.php
@@ -98,7 +98,7 @@
 			<?php } ?>
 
 				<?php if ( display_header_text() ) : ?>
-					<p id="logo"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" title="Zur Startseite"><img src="<?php echo get_template_directory_uri(); ?>/lib/images/logo.png" width="185" height="100" alt="<?php bloginfo('name'); ?>"></a></p>
+					<p id="logo"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" title="Zur Startseite"><img src="<?php echo get_stylesheet_directory_uri(); ?>/lib/images/logo.png" width="185" height="100" alt="<?php bloginfo('name'); ?>"></a></p>
 					
 					<div class="hgroup">
 						<h1 id="site-title"><span><a href="<?php echo esc_url( home_url( '/' ) ); ?>" title="<?php echo esc_attr( get_bloginfo( 'name', 'display' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></span></h1>


### PR DESCRIPTION
Durch die Verwendung von `get_stylesheet_directory_uri()` anstelle von `get_template_directory_uri()` kann das im Childtheme hinterlegte Logo überschrieben werden und somit eine z.B. lokalisierte Logo-Variante verwendet werden.