### PR TITLE
updated gallery style for WordPress 5.3

### DIFF
--- a/functions/theme-functions.php
+++ b/functions/theme-functions.php
@@ -84,7 +84,7 @@ function kr8_remove_recent_comments_style() {
 
 // remove injected CSS from gallery
 function kr8_gallery_style($css) {
-	return preg_replace("!<style type='text/css'>(.*?)</style>!s", '', $css);
+	return preg_replace("!<style type=(?:\'|\")text\/css(?:\'|\")>(.*?)</style>!s", '', $css);
 }
 
 /*********************


### PR DESCRIPTION
With the update to WordPress 5.3 the style tag in front of the gallery element was changed from single quotes to double quotes. The current RegEx only handled single quotes. Therefore the default style tag wasn't removed properly and the gallery design failed for the Urwahl3000 theme. With this new RegEx both, single and double quotes, are recognized and the gallery is shown correctly in WordPress version 5.3 and lower versions.