### PR TITLE
Fix image caption in left or right aligned images.

### DIFF
--- a/lib/css/style.css
+++ b/lib/css/style.css
@@ -1220,13 +1220,13 @@ body {}
   .entry-content .alignleft,
   .entry-content img.alignleft {
     margin-right: 1.5em;
-    display: inline;
+    display: table;
     float: left;
   }
   .entry-content .alignright,
   .entry-content img.alignright {
     margin-left: 1.5em;
-    display: inline;
+    display: table;
     float: right;
   }
   .entry-content .aligncenter,


### PR DESCRIPTION
Die Bildunterschrift `<figcaption>` wird mit `display: table-caption` dargestellt, jedoch wird das übergeordnete Element `figure` auf großen Bildschirmen mit `inline` dargestellt. mMn müsste es hier `table` lauten.

Beispiel für das Problem:
https://gruene-lippe.de/kreisverband/vorstand/