### PR TITLE
Fix paged breadcrumb naming

### DIFF
--- a/functions/theme-functions.php
+++ b/functions/theme-functions.php
@@ -714,9 +714,7 @@ function nav_breadcrumb() {
     }
  
     if ( get_query_var('paged') ) {
-      if ( is_category() || is_day() || is_month() || is_year() || is_search() || is_tag() || is_author() ) echo ' (';
-      echo ': ' . __('Seite') . ' ' . get_query_var('paged');
-      if ( is_category() || is_day() || is_month() || is_year() || is_search() || is_tag() || is_author() ) echo ')';
+      echo '(' . __('Seite') . ' ' . get_query_var('paged') . ')';
     }
  
     echo '</div>';


### PR DESCRIPTION
Ich nochmal.

Wenn man innerhalb der Startseite auf die nächste Seite wechselt, dann sieht das im Breadcrumb so aus:
`Startseite ⟩ Nachrichten: Seite 2`

Bei Kategorien: `Startseite ⟩ Kreistagsfraktion ⟩ Anträge (: Seite 2)`
Bei Jahren: `Startseite ⟩ 2019 (: Seite 2)`
Bei der Suche: `Startseite ⟩ Ergebnisse für die Suche nach "Grüne" (: Seite 2)`
Bei Author: `Startseite ⟩ Beiträge veröffentlicht von %NAME% (: Seite 2)`

Mein Vorschlag wäre dies zu vereinfachen und immer XXX (Seite %NUMMER%) zu schreiben. => Immer mit Klammerung. Kein Doppelpunkt.

Dieser Code wurde seit der initialen Version nie geändert.