### PR TITLE
Fix hr style

### DIFF
--- a/lib/css/style.css
+++ b/lib/css/style.css
@@ -166,7 +166,7 @@ table, tr, td {vertical-align: top;}
 
 p.intro {font-family: 'PT Sans Bold', Trebuchet, Helvetica Neue, Helvetica, Arial, Verdana, sans-serif;font-size:1.1em;}
 
-hr {border: 0; background: #e6e6e6; height: 3px;width: 95%;margin: 2.5em auto 0;}
+hr {border: 0; background: #e6e6e6; height: 3px;width: 95%;margin: 2.5em auto;}
 
 strong, b {font-family: 'PT Sans Bold', Trebuchet, Helvetica Neue, Helvetica, Arial, Verdana, sans-serif;font-weight: normal;}
 


### PR DESCRIPTION
http://demo.urwahl3000.de/text-stile/
Dort steht, wie die horizontale Linie zu verwenden ist. Demnach wird dort eine leere Zeile mit einem geschützten Leerzeichen  `&nbsp;` verwendet. Insbesondere mit dem neuen Gutenberg-Editor sollte man Inhalt und Layout trennen. Der Vorschlag ist natürlich ein breaking change!

**Hier Vorschau im Editor:**
![image](https://user-images.githubusercontent.com/6826752/71077773-601cf200-2188-11ea-8d09-89fd91e1abd7.png)

### **Vorher:**
![image](https://user-images.githubusercontent.com/6826752/71077938-ae31f580-2188-11ea-9928-0e1866505455.png)

### **Nachher:**
![image](https://user-images.githubusercontent.com/6826752/71078009-d4579580-2188-11ea-902b-3d1f4e62263f.png)

### **Nachher Variante:**
`margin: 2.5em auto 2em;`
Dies ist noch eine Variante die dem Auge optisch noch besser zusagt. Die Abstände nach oben und unten sind dadurch nicht mehr gleich, sondern nach unten hin fehlen 0.5em. Sieht mMn noch etwas besser aus.

![image](https://user-images.githubusercontent.com/6826752/71078044-e76a6580-2188-11ea-9436-645e4a2bc4d2.png)
