### PR TITLE
Fix breadcrumb on empty tag page

### DIFF
--- a/functions/theme-functions.php
+++ b/functions/theme-functions.php
@@ -647,6 +647,9 @@ function nav_breadcrumb() {
       $parentCat = get_category($thisCat->parent);
       if ($thisCat->parent != 0) echo(get_category_parents($parentCat, TRUE, ' ' . $delimiter . ' '));
       echo $before . single_cat_title('', false) . $after;
+
+    } elseif ( is_tag() ) {
+      echo $before . 'Beiträge mit dem Schlagwort "' . single_tag_title('', false) . '"' . $after;
  
     } elseif ( is_day() ) {
       echo '<a href="' . get_year_link(get_the_time('Y')) . '">' . get_the_time('Y') . '</a> ' . $delimiter . ' ';
@@ -701,9 +704,6 @@ function nav_breadcrumb() {
       $breadcrumbs = array_reverse($breadcrumbs);
       foreach ($breadcrumbs as $crumb) echo $crumb . ' ' . $delimiter . ' ';
       echo $before . get_the_title() . $after;
- 
-    } elseif ( is_tag() ) {
-      echo $before . 'Beiträge mit dem Schlagwort "' . single_tag_title('', false) . '"' . $after;
  
     } elseif ( is_author() ) {
        global $author;

--- a/functions/theme-functions.php
+++ b/functions/theme-functions.php
@@ -649,7 +649,7 @@ function nav_breadcrumb() {
       echo $before . single_cat_title('', false) . $after;
 
     } elseif ( is_tag() ) {
-      echo $before . 'Beiträge mit dem Schlagwort "' . single_tag_title('', false) . '"' . $after;
+      echo $before . 'Beiträge mit dem Schlagwort „' . single_tag_title('', false) . '“' . $after;
  
     } elseif ( is_day() ) {
       echo '<a href="' . get_year_link(get_the_time('Y')) . '">' . get_the_time('Y') . '</a> ' . $delimiter . ' ';
@@ -676,7 +676,7 @@ function nav_breadcrumb() {
       }
  
     } elseif ( is_search() ) {
-      echo $before . 'Ergebnisse für die Suche nach "' . get_search_query() . '"' . $after;
+      echo $before . 'Ergebnisse für die Suche nach „' . get_search_query() . '“' . $after;
  
     } elseif ( !is_single() && !is_page() && get_post_type() != 'post' && !is_404() ) {
       $post_type = get_post_type_object(get_post_type());


### PR DESCRIPTION
The Breadcrumb navigation on an empty tag page did not display anything
and generated a notice because it used another case (L680).