### PR TITLE
custom-logo

### DIFF
--- a/functions/theme-functions.php
+++ b/functions/theme-functions.php
@@ -316,6 +316,15 @@ function custom_theme_features()  {
 
 	);
 	add_theme_support( 'custom-header', $header_args );
+	
+	// Add theme support for Custom Logo
+	$logo_args = array(
+		'width'                  => 185,
+		'height'                 => 100,
+		'flex-height'            => true,
+		'flex-width'             => true
+	);
+	add_theme_support( 'custom-logo', $logo_args );
 
 }
 

--- a/header.php
+++ b/header.php
@@ -101,7 +101,11 @@
 					<p id="logo"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" title="Zur Startseite"><img src="
 					<?php 	$vectorlogo = 'lib/images/logo.svg';
 							$pixellogo = 'lib/images/logo.png';
-							if( file_exists( trailingslashit( get_stylesheet_directory() ) . $vectorlogo ) ) {
+							if ( has_custom_logo() ) {
+								$custom_logo_id = get_theme_mod( 'custom_logo' );
+								$custom_logo = wp_get_attachment_image_src( $custom_logo_id , 'full' );
+								$logo = esc_url( $custom_logo[0] );		
+							} else if( file_exists( trailingslashit( get_stylesheet_directory() ) . $vectorlogo ) ) {
 								$logo = trailingslashit( get_stylesheet_directory() ) . $vectorlogo;
 							} elseif( file_exists( trailingslashit( get_stylesheet_directory() ) . $pixellogo ) ) {
 								$logo = trailingslashit( get_stylesheet_directory() ) . $pixellogo;


### PR DESCRIPTION
Hallo zusammen,

wir wollen für unseren Ortsverband das Logo mit dem Ortsnamen im blauen Banner verwenden. Das würde wohl über Child-Themes auch gehen, aber ich finde den Weg über den Customizer einfacher. Daher habe ich es eingebaut und hoffe, es gefällt euch.

Das geht wie folgt: Design -> Customizer -> Website-Informationen -> Logo auswählen

Ich habe zwei Screenshots angehängt: Wo man das Logo auswählen kann und wie es auf der Beispiel-Seite aussieht.

![custom-logo-1](https://user-images.githubusercontent.com/58371839/113480141-3548d100-9493-11eb-8c1e-e61286e87506.png)
![custom-logo-2](https://user-images.githubusercontent.com/58371839/113480142-35e16780-9493-11eb-959f-db70f6c5ab09.png)

Grüße, Jürgen